### PR TITLE
Override username from nick of user info

### DIFF
--- a/lib/omniauth/strategies/dingding.rb
+++ b/lib/omniauth/strategies/dingding.rb
@@ -24,7 +24,7 @@ module OmniAuth
       info do
         {
           unionid: user_info['unionid'],
-          name: user_info['nick'],
+          username: user_info['nick'],
           ding_id: user_info['dingId']
         }.merge(user_info)
       end


### PR DESCRIPTION
从钉钉返回的 `nick` 指的是用户的真是姓名, 在大多数时候是我们想要的 `username` .